### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,7 +299,7 @@ The `superlite` version includes all the necessary libraries to run 32-64 bit ap
 * Add launching `socat` `dbus` proxy if `*_NET*` and `DBUS_SESSION_BUS_ADDRESS` =~ `unix:abstract`
 * Add `RUNPPID` Parent PID of `Run.sh` script
 * Fix sometimes killing parent PID on container exit if `PID_MAX` is too small
-* Add warning and recomendation if `PID_MAX` is less than `4194304`
+* Add warning and recommendation if `PID_MAX` is less than `4194304`
 * Remove `headpid`
 * Add [ptyspawn](https://github.com/VHSgunzo/ptyspawn)
 * Update [bubblewrap](https://github.com/VHSgunzo/bubblewrap-static/releases/tag/v0.7.0.r8) v0.7.0.r8

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ chmod +x runimage
 
 Only for not extracted (RunImage runtime options):
     --runtime-extract {pattern}          Extract content from embedded filesystem image
-    --runtime-extract-and-run {args}     Run runimage afer extraction without using FUSE
+    --runtime-extract-and-run {args}     Run runimage after extraction without using FUSE
     --runtime-help                       Show runimage runtime help (Shown in this help)
     --runtime-mount                      Mount embedded filesystem image and print
     --runtime-offset                     Print byte offset to start of embedded
@@ -134,7 +134,7 @@ Environment variables to configure:
     QUIET_MODE=1                         Disables all non-error runimage messages
     NO_WARN=1                            Disables all warning runimage messages
     DONT_NOTIFY=1                        Disables all non-error runimage notification
-    RUNTIME_EXTRACT_AND_RUN=1            Run runimage afer extraction without using FUSE
+    RUNTIME_EXTRACT_AND_RUN=1            Run runimage after extraction without using FUSE
     TMPDIR="/path/{TMPDIR}"              Used for extract and run options
     RUNIMAGE_CONFIG="/path/{config}"     runimage сonfiguration file (0 to disable)
     ENABLE_HOSTEXEC=1                    Enables the ability to execute commands at the host level

--- a/rootfs/usr/share/libalpm/hooks/fix-resolvconf.hook
+++ b/rootfs/usr/share/libalpm/hooks/fix-resolvconf.hook
@@ -7,4 +7,4 @@ Target = usr/bin/resolvconf
 [Action]
 Description = Updating resolvconf...
 When = PostTransaction
-Exec = /usr/bin/sh -c 'sed -i "s|warn \"could not detect a useable init system\"|# &|g" /usr/bin/resolvconf'
+Exec = /usr/bin/sh -c 'sed -i "s|warn \"could not detect a usable init system\"|# &|g" /usr/bin/resolvconf'

--- a/rootfs/var/RunDir/Run.sh
+++ b/rootfs/var/RunDir/Run.sh
@@ -1310,7 +1310,7 @@ ${GREEN}RunImage ${RED}v${RUNIMAGE_VERSION} ${GREEN}by $DEVELOPERS
 
     ${RED}Only for not extracted (RunImage runtime options):
         ${BLUE}--runtime-extract$YELLOW {pattern}$GREEN          Extract content from embedded filesystem image
-        ${BLUE}--runtime-extract-and-run $YELLOW{args}$GREEN     Run runimage afer extraction without using FUSE
+        ${BLUE}--runtime-extract-and-run $YELLOW{args}$GREEN     Run runimage after extraction without using FUSE
         ${BLUE}--runtime-help$GREEN                       Show runimage runtime help (Shown in this help)
         ${BLUE}--runtime-mount$GREEN                      Mount embedded filesystem image and print
         ${BLUE}--runtime-offset$GREEN                     Print byte offset to start of embedded
@@ -1359,7 +1359,7 @@ ${GREEN}RunImage ${RED}v${RUNIMAGE_VERSION} ${GREEN}by $DEVELOPERS
         ${YELLOW}QUIET_MODE$GREEN=1                         Disables all non-error runimage messages
         ${YELLOW}NO_WARN$GREEN=1                            Disables all warning runimage messages
         ${YELLOW}DONT_NOTIFY$GREEN=1                        Disables all non-error runimage notification
-        ${YELLOW}RUNTIME_EXTRACT_AND_RUN$GREEN=1            Run runimage afer extraction without using FUSE
+        ${YELLOW}RUNTIME_EXTRACT_AND_RUN$GREEN=1            Run runimage after extraction without using FUSE
         ${YELLOW}TMPDIR$GREEN=\"/path/{TMPDIR}\"              Used for extract and run options
         ${YELLOW}RUNIMAGE_CONFIG$GREEN=\"/path/{config}\"     runimage сonfiguration file (0 to disable)
         ${YELLOW}ENABLE_HOSTEXEC$GREEN=1                    Enables the ability to execute commands at the host level


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.